### PR TITLE
Add shared character state, wire Basic Info/Class/Race/Abilities to P…

### DIFF
--- a/pf-builder/src/context/CharacterContext.js
+++ b/pf-builder/src/context/CharacterContext.js
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+const CharacterContext = React.createContext(null);
+
+const initialCharacter = {
+	info: {
+		name: '', player: '', alignment: '', deity: '', homeland: '',
+		gender: '', age: '', height: '', weight: '', hair: '', eyes: '',
+	},
+	classInfo: { className: '', level: '' },
+	race: { name: '' },
+	abilities: {
+		str: '', dex: '', con: '', int: '', wis: '', cha: '',
+		generationMethod: '', rolls: [], pointBuyCampaign: '',
+	},
+};
+
+export function CharacterProvider({ children }) {
+	const [character, setCharacter] = React.useState(initialCharacter);
+
+	const updateSection = (section) => (patch) =>
+		setCharacter((prev) => ({ ...prev, [section]: { ...prev[section], ...patch } }));
+
+	const value = {
+		character,
+		updateInfo: updateSection('info'),
+		updateClass: updateSection('classInfo'),
+		updateRace: updateSection('race'),
+		updateAbilities: updateSection('abilities'),
+	};
+
+	return (
+		<CharacterContext.Provider value={value}>
+			{children}
+		</CharacterContext.Provider>
+	);
+}
+
+export function useCharacter() {
+	const context = React.useContext(CharacterContext);
+	if (!context) {
+		throw new Error('useCharacter must be used within a CharacterProvider');
+	}
+	return context;
+}

--- a/pf-builder/src/index.js
+++ b/pf-builder/src/index.js
@@ -12,6 +12,7 @@ import Skills from './pages/skills/Skills';
 import Abilities from './pages/abilities/Abilities';
 import Equipment from './pages/equipment/Equipment';
 import Finalize from './pages/finalize/Finalize';
+import { CharacterProvider } from './context/CharacterContext';
 import {
 	createHashRouter,
 	RouterProvider,
@@ -64,8 +65,10 @@ const router = createHashRouter([
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
 	<React.StrictMode>
-		<RouterProvider router={router} />
-		<Footer />
+		<CharacterProvider>
+			<RouterProvider router={router} />
+			<Footer />
+		</CharacterProvider>
 	</React.StrictMode>
 );
 

--- a/pf-builder/src/pages/abilities/Abilities.js
+++ b/pf-builder/src/pages/abilities/Abilities.js
@@ -1,45 +1,204 @@
 import * as React from 'react';
-import { Box, MenuItem, Typography, FormControl, InputLabel, Card, CardContent } from '@mui/material';
-import Select from '@mui/material/Select';
+import { Box, Button, FormControl, InputLabel, MenuItem, Select, Typography } from '@mui/material';
+import CardSelector from '../../components/CardSelector';
+import { useCharacter } from '../../context/CharacterContext';
+import {
+	STANDARD_ARRAY,
+	POINT_BUY_COSTS,
+	CAMPAIGN_POINT_BUDGETS,
+	formatModifier,
+	rollSixAbilityScores,
+	getAvailableOptions,
+} from '../../utils/abilityScore';
+
+const abilityFields = [
+	{ key: 'str', label: 'Strength' },
+	{ key: 'dex', label: 'Dexterity' },
+	{ key: 'con', label: 'Constitution' },
+	{ key: 'int', label: 'Intelligence' },
+	{ key: 'wis', label: 'Wisdom' },
+	{ key: 'cha', label: 'Charisma' },
+];
+
+function AbilityRow({ label, score, control, extra }) {
+	return (
+		<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, marginTop: 1 }}>
+			<Typography sx={{ width: 140 }}>{label}</Typography>
+			{control}
+			<Typography sx={{ width: 40 }} variant="body2">{formatModifier(score)}</Typography>
+			{extra}
+		</Box>
+	);
+}
 
 export default function Abilities() {
-	const [selection, setSelection] = React.useState('');
-
-	const handleChange = (event) => {
-		setSelection(event.target.value);
+	const { character, updateAbilities } = useCharacter();
+	const { abilities } = character;
+	const currentScores = {
+		str: abilities.str, dex: abilities.dex, con: abilities.con,
+		int: abilities.int, wis: abilities.wis, cha: abilities.cha,
 	};
 
+	const handleMethodChange = (event) => {
+		updateAbilities({
+			generationMethod: event.target.value,
+			str: '', dex: '', con: '', int: '', wis: '', cha: '',
+		});
+	};
 
+	const handleAssignChange = (key) => (event) => {
+		const value = event.target.value;
+		updateAbilities({ [key]: value === '' ? '' : Number(value) });
+	};
+
+	const handleRoll = () => {
+		updateAbilities({
+			rolls: rollSixAbilityScores(),
+			str: '', dex: '', con: '', int: '', wis: '', cha: '',
+		});
+	};
+
+	const handleCampaignChange = (event) => {
+		updateAbilities({
+			pointBuyCampaign: event.target.value,
+			str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10,
+		});
+	};
+
+	const handlePointBuyChange = (key) => (event) => {
+		updateAbilities({ [key]: Number(event.target.value) });
+	};
+
+	const renderAssignmentRows = (pool) => (
+		abilityFields.map(({ key, label }) => {
+			const options = getAvailableOptions(pool, currentScores, key);
+			return (
+				<AbilityRow
+					key={key}
+					label={label}
+					score={abilities[key]}
+					control={
+						<FormControl sx={{ minWidth: 100 }} size="small">
+							<Select value={abilities[key]} displayEmpty onChange={handleAssignChange(key)}>
+								<MenuItem value=""><em>—</em></MenuItem>
+								{options.map((v) => (
+									<MenuItem key={v} value={v}>{v}</MenuItem>
+								))}
+							</Select>
+						</FormControl>
+					}
+				/>
+			);
+		})
+	);
+
+	const pointBuyBudget = CAMPAIGN_POINT_BUDGETS[abilities.pointBuyCampaign];
+	const pointBuySpent = abilityFields.reduce((sum, { key }) => {
+		const score = abilities[key];
+		return sum + (POINT_BUY_COSTS[score] ?? 0);
+	}, 0);
+	const pointBuyRemaining = pointBuyBudget !== undefined ? pointBuyBudget - pointBuySpent : undefined;
 
 	return (
 		<div>
-			<Card>
-				<CardContent>
-					<Typography variant="body2">
-						Ability Scores
-					</Typography>
-					<br />
-					<FormControl fullWidth>
-						<InputLabel>Choose a generation method</InputLabel>
-						<Select
-							label="Choose a generation method"
-							onChange={handleChange}
-						>
-							<MenuItem value={10}>Standard Array</MenuItem>
-							<MenuItem value={20}>Point Buy</MenuItem>
-							<MenuItem value={30}>Manual/Rolled</MenuItem>
-						</Select>
-					</FormControl>
-					{selection && (
-						<span>
-							<Typography variant="body2" sx={{ marginTop: 1 }}>
-								{selection}
-							</Typography>
-						</span>
-					)}
-				</CardContent>
-			</Card>
+			<Box sx={{ marginTop: 2, marginLeft: 2, marginRight: 2 }}>
+				<Typography variant="body2">
+					Ability Scores
+				</Typography>
+			</Box>
+			<CardSelector
+				title={"Choose a generation method"}
+				value={abilities.generationMethod}
+				onChange={handleMethodChange}
+			>
+				<MenuItem value={'Standard Array'}>Standard Array</MenuItem>
+				<MenuItem value={'Point Buy'}>Point Buy</MenuItem>
+				<MenuItem value={'Manual/Rolled'}>Manual/Rolled</MenuItem>
 
+				{abilities.generationMethod === 'Standard Array' && (
+					<span>
+						<Typography variant="body2">
+							Assign each score to an ability: {STANDARD_ARRAY.join(', ')}
+						</Typography>
+						{renderAssignmentRows(STANDARD_ARRAY)}
+					</span>
+				)}
+
+				{abilities.generationMethod === 'Manual/Rolled' && (
+					<span>
+						<Typography variant="body2">
+							Roll 4d6, drop the lowest die, and add the rest — six times. Assign each total to an ability afterward.
+						</Typography>
+						<Button variant="outlined" size="small" sx={{ marginTop: 1 }} onClick={handleRoll}>
+							{abilities.rolls.length ? 'Reroll' : 'Roll Scores'}
+						</Button>
+						{abilities.rolls.length > 0 && (
+							<>
+								<Typography variant="body2" sx={{ marginTop: 1 }}>
+									Rolled: {abilities.rolls.join(', ')}
+								</Typography>
+								{renderAssignmentRows(abilities.rolls)}
+							</>
+						)}
+					</span>
+				)}
+
+				{abilities.generationMethod === 'Point Buy' && (
+					<span>
+						<FormControl sx={{ minWidth: 220 }} size="small">
+							<InputLabel>Campaign Type</InputLabel>
+							<Select label="Campaign Type" value={abilities.pointBuyCampaign} onChange={handleCampaignChange}>
+								{Object.entries(CAMPAIGN_POINT_BUDGETS).map(([name, points]) => (
+									<MenuItem key={name} value={name}>{name} ({points} points)</MenuItem>
+								))}
+							</Select>
+						</FormControl>
+
+						{abilities.pointBuyCampaign && (
+							<>
+								<Typography
+									variant="body2"
+									sx={{ marginTop: 1, color: pointBuyRemaining < 0 ? 'error.main' : 'text.primary' }}
+								>
+									Points remaining: {pointBuyRemaining} / {pointBuyBudget}
+								</Typography>
+								{abilityFields.map(({ key, label }) => {
+									const spentWithoutKey = pointBuySpent - (POINT_BUY_COSTS[abilities[key]] ?? 0);
+									const currentCost = POINT_BUY_COSTS[abilities[key]] ?? 0;
+									return (
+										<AbilityRow
+											key={key}
+											label={label}
+											score={abilities[key]}
+											extra={
+												<Typography sx={{ width: 70 }} variant="caption" color="text.secondary">
+													{currentCost >= 0 ? '+' : ''}{currentCost} pts
+												</Typography>
+											}
+											control={
+												<FormControl sx={{ minWidth: 150 }} size="small">
+													<Select value={abilities[key]} onChange={handlePointBuyChange(key)}>
+														{Object.keys(POINT_BUY_COSTS).map((scoreStr) => {
+															const score = Number(scoreStr);
+															const cost = POINT_BUY_COSTS[score];
+															const affordable = score === abilities[key] || spentWithoutKey + cost <= pointBuyBudget;
+															return (
+																<MenuItem key={score} value={score} disabled={!affordable}>
+																	{score} ({cost >= 0 ? '+' : ''}{cost} pts)
+																</MenuItem>
+															);
+														})}
+													</Select>
+												</FormControl>
+											}
+										/>
+									);
+								})}
+							</>
+						)}
+					</span>
+				)}
+			</CardSelector>
 		</div>
 	);
 }

--- a/pf-builder/src/pages/class/Class.js
+++ b/pf-builder/src/pages/class/Class.js
@@ -1,12 +1,18 @@
 import * as React from 'react';
-import { Box, MenuItem, Typography } from '@mui/material';
+import { Box, MenuItem, TextField, Typography } from '@mui/material';
 import CardSelector from '../../components/CardSelector';
+import { useCharacter } from '../../context/CharacterContext';
 
 export default function Class() {
-	const [selectedClass, setSelectedClass] = React.useState('');
+	const { character, updateClass } = useCharacter();
+	const selectedClass = character.classInfo.className;
 
 	const handleClassChange = (event) => {
-		setSelectedClass(event.target.value);
+		updateClass({ className: event.target.value });
+	};
+
+	const handleLevelChange = (event) => {
+		updateClass({ level: event.target.value });
 	};
 
 	const classInfo = {
@@ -50,6 +56,15 @@ export default function Class() {
 					</span>
 				)}
 			</CardSelector>
+			<Box sx={{ marginTop: 2, marginLeft: 2, marginRight: 2, maxWidth: 200 }}>
+				<TextField
+					label="Level"
+					type="number"
+					fullWidth
+					value={character.classInfo.level}
+					onChange={handleLevelChange}
+				/>
+			</Box>
 		</div>
 	);
 }

--- a/pf-builder/src/pages/finalize/Finalize.js
+++ b/pf-builder/src/pages/finalize/Finalize.js
@@ -1,9 +1,19 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PDFDocument } from "pdf-lib";
 import characterSheet from './Pathfinder_en.pdf'
+import { useCharacter } from '../../context/CharacterContext';
+import { raceInfo } from '../race/Race';
+import { formatModifier } from '../../utils/abilityScore';
+
+const alignmentAbbreviations = {
+	'Lawful Good': 'LG', 'Neutral Good': 'NG', 'Chaotic Good': 'CG',
+	'Lawful Neutral': 'LN', 'True Neutral': 'N', 'Chaotic Neutral': 'CN',
+	'Lawful Evil': 'LE', 'Neutral Evil': 'NE', 'Chaotic Evil': 'CE',
+};
 
 const PdfEditor = () => {
 	const [pdfUrl, setPdfUrl] = useState(null);
+	const { character } = useCharacter();
 
 	const fillPdf = async () => {
 		// Fetch the existing PDF
@@ -18,31 +28,32 @@ const PdfEditor = () => {
 		const pages = pdfDoc.getPages();
 		const firstPage = pages[0];
 		const secondPage = pages[1];
-		const deity = "Deity";
+		const deity = character.info.deity || "";
 
 
 		// #region Page 1
 
 		// #region Character Info
-		firstPage.drawText("Character Name", {
+		firstPage.drawText(character.info.name || "", {
 			x: 240,
 			y: 730,
 			size: 14
 		});
 
-		firstPage.drawText("LG", {
+		firstPage.drawText(alignmentAbbreviations[character.info.alignment] || "", {
 			x: 380,
 			y: 730,
 			size: 14
 		});
 
-		firstPage.drawText("Player", {
+		firstPage.drawText(character.info.player || "", {
 			x: 425,
 			y: 730,
 			size: 14
 		});
 
-		firstPage.drawText("Character Level", {
+		// No dedicated "Class" field exists on this sheet, so Class + Level share the "Character Level" line.
+		firstPage.drawText(`${character.classInfo.className} ${character.classInfo.level}`.trim(), {
 			x: 240,
 			y: 711,
 			size: 10
@@ -54,55 +65,55 @@ const PdfEditor = () => {
 			size: 10
 		});
 
-		firstPage.drawText("Homeland", {
+		firstPage.drawText(character.info.homeland || "", {
 			x: 505,
 			y: 711,
 			size: 10
 		});
 
-		firstPage.drawText("Race", {
+		firstPage.drawText(character.race.name || "", {
 			x: 240,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("Size", {
+		firstPage.drawText(raceInfo[character.race.name]?.size || "", {
 			x: 325,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("F", {
+		firstPage.drawText(character.info.gender || "", {
 			x: 360,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("Age", {
+		firstPage.drawText(character.info.age || "", {
 			x: 395,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("Height", {
+		firstPage.drawText(character.info.height || "", {
 			x: 425,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("Weight", {
+		firstPage.drawText(character.info.weight || "", {
 			x: 460,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("Hair", {
+		firstPage.drawText(character.info.hair || "", {
 			x: 500,
 			y: 692,
 			size: 10
 		});
 
-		firstPage.drawText("Eyes", {
+		firstPage.drawText(character.info.eyes || "", {
 			x: 530,
 			y: 692,
 			size: 10
@@ -113,132 +124,133 @@ const PdfEditor = () => {
 		// #region Ability Scores
 
 		// STR
-		firstPage.drawText("10", {
+		firstPage.drawText(String(character.abilities.str || ""), {
 			x: 73,
 			y: 651,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText(formatModifier(character.abilities.str), {
 			x: 100,
 			y: 651,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		// Temp Score / Temp Modifier columns intentionally left blank — no UI yet for temporary ability adjustments.
+		firstPage.drawText("", {
 			x: 127,
 			y: 651,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 155,
 			y: 651,
 			size: 12
 		});
 
 		// DEX
-		firstPage.drawText("10", {
+		firstPage.drawText(String(character.abilities.dex || ""), {
 			x: 73,
 			y: 633,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText(formatModifier(character.abilities.dex), {
 			x: 100,
 			y: 633,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 127,
 			y: 633,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 155,
 			y: 633,
 			size: 12
 		});
 
 		// CON
-		firstPage.drawText("10", {
+		firstPage.drawText(String(character.abilities.con || ""), {
 			x: 73,
 			y: 617,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText(formatModifier(character.abilities.con), {
 			x: 100,
 			y: 617,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 127,
 			y: 617,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 155,
 			y: 617,
 			size: 12
 		});
 
 		// INT
-		firstPage.drawText("10", {
+		firstPage.drawText(String(character.abilities.int || ""), {
 			x: 73,
 			y: 600,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText(formatModifier(character.abilities.int), {
 			x: 100,
 			y: 600,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 127,
 			y: 600,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 155,
 			y: 600,
 			size: 12
 		});
 
 		// WIS
-		firstPage.drawText("10", {
+		firstPage.drawText(String(character.abilities.wis || ""), {
 			x: 73,
 			y: 581,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText(formatModifier(character.abilities.wis), {
 			x: 100,
 			y: 581,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 127,
 			y: 581,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 155,
 			y: 581,
 			size: 12
 		});
 
 		// CHA
-		firstPage.drawText("10", {
+		firstPage.drawText(String(character.abilities.cha || ""), {
 			x: 73,
 			y: 565,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText(formatModifier(character.abilities.cha), {
 			x: 100,
 			y: 565,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 127,
 			y: 565,
 			size: 12
 		});
-		firstPage.drawText("10", {
+		firstPage.drawText("", {
 			x: 155,
 			y: 565,
 			size: 12
@@ -309,6 +321,9 @@ const PdfEditor = () => {
 			size: 12
 		});
 
+		// KNOWN BUG (pre-existing, out of scope for this phase): this draw duplicates the one
+		// immediately above at the same x/y — likely meant to be a different field. Investigate
+		// when the Character Stats region gets wired to real data.
 		// AC
 		firstPage.drawText("AC", {
 			x: 73,
@@ -1934,6 +1949,8 @@ const PdfEditor = () => {
 			size: 14
 		});
 
+		// KNOWN BUG (pre-existing, out of scope for this phase): this 6th row is missing its
+		// "Item N" name draw (present on all 5 rows above) — fix when this region gets real data.
 		secondPage.drawText("0", {
 			x: 160,
 			y: 618,
@@ -3003,16 +3020,22 @@ const PdfEditor = () => {
 		setPdfUrl(pdfUrl);
 	};
 
+	useEffect(() => {
+		fillPdf();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	return (
 		<div>
-			<button onClick={fillPdf}>Fill PDF</button>
-			{pdfUrl && (
+			{pdfUrl ? (
 				<iframe
 					src={pdfUrl}
 					width="100%"
 					height="500px"
 					title="Filled PDF"
 				/>
+			) : (
+				<p>Generating character sheet...</p>
 			)}
 		</div>
 	);

--- a/pf-builder/src/pages/homePage/Home.js
+++ b/pf-builder/src/pages/homePage/Home.js
@@ -1,10 +1,48 @@
 import * as React from 'react';
-import CardRoot from '../../components/CardRoot';
+import { Box, Card, CardContent, FormControl, InputLabel, MenuItem, Select, TextField, Typography } from '@mui/material';
+import { useCharacter } from '../../context/CharacterContext';
+
+const alignments = [
+	'Lawful Good', 'Neutral Good', 'Chaotic Good',
+	'Lawful Neutral', 'True Neutral', 'Chaotic Neutral',
+	'Lawful Evil', 'Neutral Evil', 'Chaotic Evil',
+];
 
 export default function Home() {
+	const { character, updateInfo } = useCharacter();
+	const { info } = character;
+
+	const handleChange = (field) => (event) => {
+		updateInfo({ [field]: event.target.value });
+	};
+
 	return (
-		<CardRoot title={"Home"}>
-			home page
-		</CardRoot>
+		<Card sx={{ backgroundColor: 'transparent', marginTop: 2, marginLeft: 2, marginRight: 2 }}>
+			<CardContent>
+				<Typography gutterBottom variant="h6" component="div">
+					Basic Info
+				</Typography>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+					<TextField label="Character Name" value={info.name} onChange={handleChange('name')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Player" value={info.player} onChange={handleChange('player')} sx={{ flex: '1 1 200px' }} />
+					<FormControl sx={{ flex: '1 1 200px' }}>
+						<InputLabel>Alignment</InputLabel>
+						<Select label="Alignment" value={info.alignment} onChange={handleChange('alignment')}>
+							{alignments.map((a) => (
+								<MenuItem key={a} value={a}>{a}</MenuItem>
+							))}
+						</Select>
+					</FormControl>
+					<TextField label="Deity" value={info.deity} onChange={handleChange('deity')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Homeland" value={info.homeland} onChange={handleChange('homeland')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Gender" value={info.gender} onChange={handleChange('gender')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Age" value={info.age} onChange={handleChange('age')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Height" value={info.height} onChange={handleChange('height')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Weight" value={info.weight} onChange={handleChange('weight')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Hair" value={info.hair} onChange={handleChange('hair')} sx={{ flex: '1 1 200px' }} />
+					<TextField label="Eyes" value={info.eyes} onChange={handleChange('eyes')} sx={{ flex: '1 1 200px' }} />
+				</Box>
+			</CardContent>
+		</Card>
 	);
 }

--- a/pf-builder/src/pages/race/Race.js
+++ b/pf-builder/src/pages/race/Race.js
@@ -1,10 +1,98 @@
 import * as React from 'react';
-import CardRoot from '../../components/CardRoot';
+import { Box, MenuItem, Typography } from '@mui/material';
+import CardSelector from '../../components/CardSelector';
+import { useCharacter } from '../../context/CharacterContext';
+
+export const raceInfo = {
+	Dwarf: {
+		description: 'Stout and hardy folk who favor stonework, grudges, and stubbornness in equal measure.',
+		abilityMods: '+2 Constitution, +2 Wisdom, -2 Charisma',
+		size: 'Medium',
+		speed: '20 ft.',
+	},
+	Elf: {
+		description: 'Graceful, long-lived wanderers with a deep connection to magic and the arcane arts.',
+		abilityMods: '+2 Dexterity, +2 Intelligence, -2 Constitution',
+		size: 'Medium',
+		speed: '30 ft.',
+	},
+	Gnome: {
+		description: 'Curious, whimsical tinkerers and illusionists with an ever-present sense of wonder.',
+		abilityMods: '+2 Constitution, +2 Charisma, -2 Strength',
+		size: 'Small',
+		speed: '20 ft.',
+	},
+	'Half-Elf': {
+		description: 'Caught between two worlds, half-elves combine human ambition with elven grace.',
+		abilityMods: 'One ability score of choice +2',
+		size: 'Medium',
+		speed: '30 ft.',
+	},
+	Halfling: {
+		description: 'Small, nimble, and endlessly optimistic folk who thrive on the fringes of larger societies.',
+		abilityMods: '+2 Dexterity, +2 Charisma, -2 Strength',
+		size: 'Small',
+		speed: '20 ft.',
+	},
+	'Half-Orc': {
+		description: 'Strong and resilient, half-orcs often struggle to find a place between human and orc society.',
+		abilityMods: 'One ability score of choice +2',
+		size: 'Medium',
+		speed: '30 ft.',
+	},
+	Human: {
+		description: 'Versatile and ambitious, humans adapt quickly and excel in nearly any role.',
+		abilityMods: 'One ability score of choice +2',
+		size: 'Medium',
+		speed: '30 ft.',
+	},
+};
 
 export default function Race() {
+	const { character, updateRace } = useCharacter();
+	const selectedRace = character.race.name;
+
+	const handleRaceChange = (event) => {
+		updateRace({ name: event.target.value });
+	};
+
+	const selected = raceInfo[selectedRace];
+
 	return (
-		<CardRoot title={"Race"}>
-			Races available: Dwarf, Elf, Gnome, Half-Elf, Halfling, Half-Orc, Human
-		</CardRoot>
+		<div>
+			<Box sx={{ marginTop: 2, marginLeft: 2, marginRight: 2 }}>
+				<Typography variant="body2">
+					Choose a race
+				</Typography>
+			</Box>
+			<CardSelector
+				title={"Race"}
+				value={selectedRace}
+				onChange={handleRaceChange}
+			>
+				{Object.keys(raceInfo).map((race) => (
+					<MenuItem key={race} value={race}>
+						{race}
+					</MenuItem>
+				))}
+
+				{selected && (
+					<span>
+						<Typography variant="body2" sx={{ marginTop: 1 }}>
+							{selected.description}
+						</Typography>
+						<Typography variant="body2" sx={{ marginTop: 1 }}>
+							Ability Modifiers: {selected.abilityMods}
+						</Typography>
+						<Typography variant="body2">
+							Size: {selected.size}
+						</Typography>
+						<Typography variant="body2">
+							Speed: {selected.speed}
+						</Typography>
+					</span>
+				)}
+			</CardSelector>
+		</div>
 	);
 }

--- a/pf-builder/src/utils/abilityScore.js
+++ b/pf-builder/src/utils/abilityScore.js
@@ -1,0 +1,57 @@
+export const STANDARD_ARRAY = [15, 14, 13, 12, 10, 8];
+
+export const POINT_BUY_COSTS = {
+	7: -4, 8: -2, 9: -1, 10: 0, 11: 1, 12: 2,
+	13: 3, 14: 5, 15: 7, 16: 10, 17: 13, 18: 17,
+};
+
+export const CAMPAIGN_POINT_BUDGETS = {
+	'Low Fantasy': 10,
+	'Standard Fantasy': 15,
+	'High Fantasy': 20,
+	'Epic Fantasy': 25,
+};
+
+export function formatModifier(score) {
+	if (score === '' || score === null || score === undefined || isNaN(score)) return '';
+	const mod = Math.floor((Number(score) - 10) / 2);
+	return mod >= 0 ? `+${mod}` : `${mod}`;
+}
+
+// Rolls 4d6, drops the lowest die, and returns the sum of the remaining three.
+export function rollAbilityScore() {
+	const dice = Array.from({ length: 4 }, () => 1 + Math.floor(Math.random() * 6));
+	dice.sort((a, b) => a - b);
+	return dice[1] + dice[2] + dice[3];
+}
+
+export function rollSixAbilityScores() {
+	return Array.from({ length: 6 }, () => rollAbilityScore());
+}
+
+// Given a pool of values (e.g. the standard array or a set of rolled scores) and the
+// currently-assigned values for every ability, returns which values are still available
+// to assign to `key` — i.e. the pool minus whatever's already used by other abilities,
+// but always including key's own current value so its selection stays valid.
+export function getAvailableOptions(pool, currentValues, key) {
+	const counts = {};
+	pool.forEach((v) => { counts[v] = (counts[v] || 0) + 1; });
+
+	Object.entries(currentValues).forEach(([k, v]) => {
+		if (k !== key && v !== '' && v !== null && v !== undefined) {
+			counts[v] = (counts[v] || 0) - 1;
+		}
+	});
+
+	const available = [];
+	Object.entries(counts).forEach(([v, count]) => {
+		for (let i = 0; i < count; i++) available.push(Number(v));
+	});
+
+	const current = currentValues[key];
+	if (current !== '' && current !== null && current !== undefined && !available.includes(Number(current))) {
+		available.push(Number(current));
+	}
+
+	return available.sort((a, b) => b - a);
+}


### PR DESCRIPTION
…DF, flesh out ability score generation

Introduces a CharacterContext so selections made across pages persist and flow into the PDF fill, which previously had no data plumbing at all.

- New CharacterContext (src/context) with section-scoped updaters, wraps the app in index.js
- Home.js: was a stub, now a real Basic Info form (name, alignment, deity, etc.)
- Class.js: migrated off local state onto shared context, added a Level field
- Race.js: converted from static text to a real selector with PF1E race data
- Abilities.js: implemented all three generation methods — Standard Array and Manual/Rolled (4d6 drop lowest, roll-and-assign UI), and Point Buy (campaign-type budgets, per-score cost table, unaffordable options disabled, live cost/remaining-points display)
- Finalize.js: now auto-fills the PDF on navigation to the page (no button), and pulls real data for the Character Info and Ability Score regions; flagged two pre-existing bugs in untouched regions with KNOWN BUG comments
- New src/utils/abilityScore.js shared by Finalize.js and Abilities.js

Skills, Equipment, and the remaining PDF regions (combat stats, weapons, gear, feats, spells) are intentionally out of scope for this pass.